### PR TITLE
Potential fix for code scanning alert no. 4: Shell command built from environment values

### DIFF
--- a/samples/test/externalclient.test.js
+++ b/samples/test/externalclient.test.js
@@ -78,16 +78,18 @@ const path = require('path');
 const http = require('http');
 
 /**
- * Runs the provided command using asynchronous child_process.exec.
+ * Runs the provided command using asynchronous child_process.execFile.
  * Unlike execSync, this works with another local HTTP server running in the
- * background.
- * @param {string} cmd The actual command string to run.
- * @param {*} opts The optional parameters for child_process.exec.
+ * background and does not invoke a shell.
+ * @param {string} cmd The command to run (for example, process.execPath).
+ * @param {string[]} [args] The list of string arguments.
+ * @param {*} opts The optional parameters for child_process.execFile.
  * @return {Promise<string>} A promise that resolves with a string
  *   corresponding with the terminal output.
  */
-const execAsync = async (cmd, opts) => {
-  const {stdout, stderr} = await exec(cmd, opts);
+const execFileAsync = promisify(cp.execFile);
+const execAsync = async (cmd, args, opts) => {
+  const {stdout, stderr} = await execFileAsync(cmd, args, opts);
   return stdout + stderr;
 };
 
@@ -284,7 +286,7 @@ describe('samples for external-account', () => {
 
     // Run sample script with GOOGLE_APPLICATION_CREDENTIALS envvar
     // pointing to the temporarily created configuration file.
-    const output = await execAsync(`${process.execPath} adc`, {
+    const output = await execAsync(process.execPath, ['adc'], {
       env: {
         ...process.env,
         GOOGLE_APPLICATION_CREDENTIALS: configFilePath,
@@ -317,7 +319,7 @@ describe('samples for external-account', () => {
     // pointing to the temporarily created configuration file.
     // This script will use signBlob to sign some data using
     // service account impersonated workload identity pool credentials.
-    const output = await execAsync(`${process.execPath} signBlob`, {
+    const output = await execAsync(process.execPath, ['signBlob'], {
       env: {
         ...process.env,
         GOOGLE_APPLICATION_CREDENTIALS: configFilePath,
@@ -383,7 +385,7 @@ describe('samples for external-account', () => {
 
     // Run sample script with GOOGLE_APPLICATION_CREDENTIALS environment
     // variable pointing to the temporarily created configuration file.
-    const output = await execAsync(`${process.execPath} adc`, {
+    const output = await execAsync(process.execPath, ['adc'], {
       env: {
         ...process.env,
         GOOGLE_APPLICATION_CREDENTIALS: configFilePath,
@@ -414,7 +416,7 @@ describe('samples for external-account', () => {
     // Run sample script with GOOGLE_APPLICATION_CREDENTIALS environment
     // variable pointing to the temporarily created configuration file.
     // Populate AWS environment variables to simulate an AWS VM.
-    const output = await execAsync(`${process.execPath} adc`, {
+    const output = await execAsync(process.execPath, ['adc'], {
       env: {
         ...process.env,
         // AWS environment variables: hardcoded region + AWS security
@@ -465,7 +467,7 @@ describe('samples for external-account', () => {
     await writeFile(executableFilePath, exeContent, {mode: 0x766});
     // Run sample script with GOOGLE_APPLICATION_CREDENTIALS environment
     // variable pointing to the temporarily created configuration file.
-    const output = await execAsync(`${process.execPath} adc`, {
+    const output = await execAsync(process.execPath, ['adc'], {
       env: {
         ...process.env,
         // Set environment variable to allow pluggable auth executable to run.

--- a/samples/test/externalclient.test.js
+++ b/samples/test/externalclient.test.js
@@ -83,7 +83,7 @@ const http = require('http');
  * background and does not invoke a shell.
  * @param {string} cmd The command to run (for example, process.execPath).
  * @param {string[]} [args] The list of string arguments.
- * @param {*} opts The optional parameters for child_process.execFile.
+ * @param {import('child_process').ExecFileOptions} opts The optional parameters for child_process.execFile.
  * @return {Promise<string>} A promise that resolves with a string
  *   corresponding with the terminal output.
  */


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/google-auth-library-nodejs/security/code-scanning/4](https://github.com/Dargon789/google-auth-library-nodejs/security/code-scanning/4)

General approach: Avoid constructing shell command strings that embed environment-derived values and are executed via `child_process.exec`. Instead, call the executable directly (here, `process.execPath`) with an argument array using `child_process.execFile` (or `spawn`), which bypasses the shell and prevents interpretation of special characters.

Best concrete fix here:

1. Change `execAsync` to accept a command **and** an optional array of arguments: `execAsync(cmd, args, opts)`.
2. Implement `execAsync` using `util.promisify(child_process.execFile)` instead of `exec`, so it does not invoke a shell.
3. Update all call sites that currently use `` execAsync(`${process.execPath} adc`, { env: ... }) `` to instead call `execAsync(process.execPath, ['adc'], { env: ... })`, and similarly for `signBlob`.
4. Keep the behavior the same: still run Node (`process.execPath`) with the same script argument (`adc`, `signBlob`) and the same environment overrides; only the invocation method changes.

Changes needed in `samples/test/externalclient.test.js`:

- Add `execFile` and `promisify`-based wrapper instead of the current `execAsync` using `exec`.
- Adjust the JSDoc for `execAsync` to mention the `args` parameter and that it no longer uses a shell.
- Update all four usages:
  - line 287: from ```${process.execPath} adc``` to `process.execPath, ['adc']`
  - line 320: same for `signBlob`
  - line 386: same for `adc`
  - line 417: same for `adc`

No other functionality is changed; we only alter how the child process is invoked.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Replace shell-based child process execution in external account sample tests with a safer, argument-based execFile wrapper.

Bug Fixes:
- Eliminate construction of shell command strings from environment-influenced values by switching from exec to execFile in tests.

Enhancements:
- Introduce a promisified execFileAsync helper that accepts a command and argument array and update JSDoc to document the safer, non-shell invocation.

Tests:
- Update external account sample integration tests to invoke Node sample scripts via execFile with explicit arguments instead of interpolated command strings.